### PR TITLE
Remove JS dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,5 @@ before_script:
 
 script:
   - sbt ++$TRAVIS_SCALA_VERSION test
-  - sbt ++$TRAVIS_SCALA_VERSION +publishLocal
+  - sbt ++$TRAVIS_SCALA_VERSION publishLocal
   - cd example && sbt ++$TRAVIS_SCALA_VERSION compile fullOptJS

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ add it manually by:
          integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" 
          crossorigin="anonymous"></script>
  ```
- * [Scala.js dependency](http://www.scala-js.org/doc/project/dependencies.html).
+ * or a [Scala.js dependency](http://www.scala-js.org/doc/project/dependencies.html).
  ```scala
  jsDependencies +=
    "org.webjars" % "jquery" % "3.3.1" / "3.3.1/jquery.js" minified "3.3.1/jquery.min.js"

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Static types for the jQuery API for [Scala.js](http://www.scala-js.org/) program
 
 ## Usage
 
-Add the following to your SBT build:
+Add the following dependency to your SBT build:
 
 ```scala
-libraryDependencies += "io.udash" %%% "udash-jquery" % "1.1.0"
+libraryDependencies += "io.udash" %%% "udash-jquery" % "2.0.0"
 ```
 
 then import the jQuery package: 
@@ -15,6 +15,21 @@ then import the jQuery package:
 ```scala
 import io.udash.wrappers.jquery._
 ```
+
+Since version `2.0.0` the wrapper does not force JS dependency on jQuery. You have to 
+add it manually by:
+ * explicit link in your `index.html`.
+ ```html
+ <script src="https://code.jquery.com/jquery-3.3.1.min.js" 
+         integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" 
+         crossorigin="anonymous"></script>
+ ```
+ * [Scala.js dependency](http://www.scala-js.org/doc/project/dependencies.html).
+ ```scala
+ jsDependencies +=
+   "org.webjars" % "jquery" % "3.3.1" / "3.3.1/jquery.js" minified "3.3.1/jquery.min.js"
+ ```
+ 
 
 ## Examples
 

--- a/build.sbt
+++ b/build.sbt
@@ -63,6 +63,9 @@ libraryDependencies ++= Seq(
   "com.lihaoyi" %%% "scalatags" % "0.6.7" % Test
 )
 
+jsDependencies +=
+  "org.webjars" % "jquery" % "3.3.1" % Test / "3.3.1/jquery.js" minified "3.3.1/jquery.min.js"
+
 lazy val root = project.in(file("."))
   .enablePlugins(ScalaJSPlugin)
   .settings(commonJSSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import org.scalajs.jsenv.selenium.SeleniumJSEnv
 name := "udash-jquery"
 
 inThisBuild(Seq(
-  version := "1.2.0",
+  version := "2.0.0",
   organization := "io.udash",
   scalaVersion := "2.12.6",
   crossScalaVersions := Seq("2.11.12", "2.12.6"),
@@ -58,13 +58,10 @@ val commonJSSettings = Seq(
 )
 
 libraryDependencies ++= Seq(
-  "org.scala-js" %%% "scalajs-dom" % "0.9.5",
+  "org.scala-js" %%% "scalajs-dom" % "0.9.6",
   "org.scalatest" %%% "scalatest" % "3.0.5" % Test,
   "com.lihaoyi" %%% "scalatags" % "0.6.7" % Test
 )
-
-jsDependencies +=
-  "org.webjars" % "jquery" % "3.3.1" / "3.3.1/jquery.js" minified "3.3.1/jquery.min.js"
 
 lazy val root = project.in(file("."))
   .enablePlugins(ScalaJSPlugin)

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -1,7 +1,7 @@
 name := "jquery-demo"
 
 inThisBuild(Seq(
-  version := "1.2.0",
+  version := "2.0.0",
   organization := "io.udash",
   scalaVersion := "2.12.6",
   scalacOptions ++= Seq(
@@ -31,6 +31,7 @@ val copyAssets = taskKey[Unit]("Copies all assets to the target directory.")
 val `jquery-demo` = project.in(file(".")).enablePlugins(ScalaJSPlugin)
   .settings(
     libraryDependencies ++= Dependencies.deps.value,
+    jsDependencies ++= Dependencies.jsDeps.value,
 
     /* move these files out of target/. */
     Compile / fullOptJS / crossTarget := generatedDir,

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -4,6 +4,7 @@ inThisBuild(Seq(
   version := "2.0.0",
   organization := "io.udash",
   scalaVersion := "2.12.6",
+  crossScalaVersions := Seq("2.11.12", "2.12.6"),
   scalacOptions ++= Seq(
     "-feature",
     "-deprecation",

--- a/example/project/Dependencies.scala
+++ b/example/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
     "io.udash" %%% "udash-jquery" % udashJQueryVersion
   ))
 
-  val jsDeps = Def.setting(Seq[JSModuleID](
+  val jsDeps = Def.setting(Seq[org.scalajs.sbtplugin.JSModuleID](
     "org.webjars" % "jquery" % "3.3.1" / "3.3.1/jquery.js" minified "3.3.1/jquery.min.js"
   ))
 }

--- a/example/project/Dependencies.scala
+++ b/example/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 
 object Dependencies {
   val udashCoreVersion = "0.6.1"
-  val udashJQueryVersion = "1.2.0"
+  val udashJQueryVersion = "2.0.0"
 
   val deps = Def.setting(Seq[ModuleID](
     "io.udash" %%% "udash-core-frontend" % udashCoreVersion,
@@ -12,5 +12,5 @@ object Dependencies {
 
   val jsDeps = Def.setting(Seq[JSModuleID](
     "org.webjars" % "jquery" % "3.3.1" / "3.3.1/jquery.js" minified "3.3.1/jquery.min.js"
-  )
+  ))
 }

--- a/example/project/Dependencies.scala
+++ b/example/project/Dependencies.scala
@@ -9,4 +9,8 @@ object Dependencies {
     "io.udash" %%% "udash-core-frontend" % udashCoreVersion,
     "io.udash" %%% "udash-jquery" % udashJQueryVersion
   ))
+
+  val jsDeps = Def.setting(Seq[JSModuleID](
+    "org.webjars" % "jquery" % "3.3.1" / "3.3.1/jquery.js" minified "3.3.1/jquery.min.js"
+  )
 }

--- a/example/project/Dependencies.scala
+++ b/example/project/Dependencies.scala
@@ -1,4 +1,5 @@
 import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
+import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 import sbt._
 
 object Dependencies {

--- a/example/project/build.properties
+++ b/example/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.1.4
+sbt.version = 1.2.0

--- a/example/project/plugins.sbt
+++ b/example/project/plugins.sbt
@@ -1,3 +1,3 @@
 logLevel := Level.Warn
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.24")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.1.4
+sbt.version = 1.2.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,4 +2,4 @@ logLevel := Level.Warn
 
 libraryDependencies += "org.scala-js" %% "scalajs-env-selenium" % "0.2.0"
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.24")


### PR DESCRIPTION
Since Scala.js 1.0 this mechanism will be "deprecated". We should migrate to [scalajs-bundler](https://scalacenter.github.io/scalajs-bundler/) in the future.